### PR TITLE
change default ALERT_WIKI_BASE_URL value to ''

### DIFF
--- a/local_config.py.example
+++ b/local_config.py.example
@@ -9,7 +9,7 @@ ICINGA_EMAIL = 'icinga@example.com'
 
 # icinga alert page base url, every notify sent by sa-icinga will be attrtched with a wiki link
 # For example : http://yourwiki.com/alerts/sshd_down
-# Set to None or '' if you don't want it.
+# Set to '' if you don't want it.
 ALERT_WIKI_BASE_URL = 'https://yourwiki.com/alerts'
 
 SMTP_SERVER = ''

--- a/sa_tools_core/consts.py
+++ b/sa_tools_core/consts.py
@@ -86,8 +86,8 @@ SENTRY_DSN = ''
 
 # icinga alert page base url, every notify sent by sa-icinga will be attrtched with a wiki link
 # For example : http://yourwiki.com/alerts/sshd_down
-# Set to None or '' if you don't want it.
-ALERT_WIKI_BASE_URL = None
+# Set to '' if you don't want it.
+ALERT_WIKI_BASE_URL = ''
 
 # notification gateway is a web service that stores and analyizes notifications. We have one in douban, you can build
 # your own.


### PR DESCRIPTION
Previously the default value of `ALERT_WIKI_BASE_URL` was set as None , which can lead to TypeError