### PR TITLE
feat: Support customized Elasticsearch timestamp field name

### DIFF
--- a/local_config.py.example
+++ b/local_config.py.example
@@ -23,6 +23,7 @@ NOTIFICATION_GATEWAY_TIMEOUT = 10  # 10s
 SA_ES_HOSTS = ['es.svc:8080']
 SA_ES_NGINX_ACCESS_INDEX_PREFIX = 'heka-nginx.access-'
 SA_ES_NGINX_ACCESS_DOC_TYPE = 'nginx.access'
+SA_ES_NGINX_ACCESS_TIMESTAMP_FIELD_NAME = "Timestamp"
 
 PROXIES = {
     "http": "http://gfw:2333",

--- a/sa_tools_core/consts.py
+++ b/sa_tools_core/consts.py
@@ -51,6 +51,7 @@ SA_ES_HOSTS = ['es.svc:8080']
 SA_ES_VERSION = (6, 4, 0)
 SA_ES_NGINX_ACCESS_INDEX_PREFIX = 'heka-nginx.access-'
 SA_ES_NGINX_ACCESS_DOC_TYPE = 'nginx.access'
+SA_ES_NGINX_ACCESS_TIMESTAMP_FIELD_NAME = "Timestamp"
 
 ########################
 # # DNS

--- a/sa_tools_core/libs/es.py
+++ b/sa_tools_core/libs/es.py
@@ -9,10 +9,11 @@ from elasticsearch import Elasticsearch, __version__ as es_client_version
 
 
 class ESQuery(object):
-    def __init__(self, es_hosts, index_prefix, doc_type):
+    def __init__(self, es_hosts, index_prefix, doc_type, timestamp_field):
         self.client = Elasticsearch(hosts=es_hosts)
         self.index_prefix = index_prefix
         self.doc_type = doc_type
+        self.timestamp_field = timestamp_field
 
     def get_mapping(self, fields=None):
         """Retrieve mapping definition of index or specific field.
@@ -37,9 +38,9 @@ class ESQuery(object):
         return start_timestamp, end_timestamp
 
     def compute_time_range(self, start_timestamp, end_timestamp):
-        time_range = dict(Timestamp=dict(gte=start_timestamp,
-                                         lte=end_timestamp,
-                                         format="epoch_second"))
+        time_range = {self.timestamp_field: {'gte': start_timestamp,
+                                             'lte': end_timestamp,
+                                             'format': "epoch_second"}}
         return time_range
 
     def compute_indexes(self, start_timestamp, end_timestamp):


### PR DESCRIPTION
This pr added an Elasticsearch timestamp field name config option so that user can define the name of the field themselves