### PR TITLE
fix long word textwrapper width must be int error

### DIFF
--- a/sa_tools_core/script.py
+++ b/sa_tools_core/script.py
@@ -44,7 +44,7 @@ FIELDS_ORDER = ('host', 'stdout', 'stderr', 'rc')
 
 def get_wrap():
     t_width = int(subprocess.check_output(['tput', 'cols']).strip())
-    wrap_width = t_width / 3
+    wrap_width = int(t_width / 3)
     return TextWrapper(width=wrap_width).wrap
 
 


### PR DESCRIPTION
In py3 division `/` has changed to "true division". Textwrap's width param can not be float. Add a `int()` will make this func compatible with both py2/3.

ref: https://www.python.org/dev/peps/pep-0238/

fix: #11 

