### PR TITLE
Bugfix/fixbase64 compare

### DIFF
--- a/sa_tools_core/libs/github.py
+++ b/sa_tools_core/libs/github.py
@@ -42,8 +42,13 @@ class GithubRepo:
         :: return
         dict
         """
-        return self.make_request('GET', f"/repos/{self.org}/{self.repo}/contents/{path}",
+        try:
+            return self.make_request('GET', f"/repos/{self.org}/{self.repo}/contents/{path}",
                                  params={'ref': reference or 'master'})
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                return None
+            raise e
 
     def get_reference(self, reference):
         return self.make_request('GET', f"/repos/{self.org}/{self.repo}/git/ref/heads/{reference}")
@@ -51,7 +56,7 @@ class GithubRepo:
     def get_commit(self, commit_sha):
         return self.make_request('GET', f"/repos/{self.org}/{self.repo}/git/commits/{commit_sha}")
 
-    def update_a_file(self, path, content, message, sha):
+    def update_a_file(self, path, content, message, sha=None):
         return self.make_request('PUT', f"/repos/{self.org}/{self.repo}/contents/{path}",
                                  data=json.dumps({
                                      'message': message,
@@ -116,7 +121,7 @@ class GithubRepo:
         # upload
         for path, content in files.items():
             base_file = self.get_file(path, reference=base_reference)
-            if base64.decodebytes(base_file['content'].encode()) == content:
+            if base_file and base64.decodebytes(base_file['content'].encode()) == content:
                 logger.info(f'{path} unchange, ignored')
                 continue
             upload_result = self.upload_one_file(content)
@@ -160,10 +165,12 @@ class GithubRepo:
             path = list(files.keys())[0]
             content = files[path]
             base_file = self.get_file(path, reference=reference)
-            if base64.decodebytes(base_file['content'].encode()) == content:
+            if not base_file:
+                self.update_a_file(path, content, message)
+            elif base64.decodebytes(base_file['content'].encode()) == content:
                 logger.info(f'{path} unchange, ignored')
             else:
-                self.update_a_file(path, content, message, base_file['sha'])
+                self.update_a_file(path, content, message, sha=base_file['sha'])
             return
 
         add_result = self.add(files, reference)

--- a/sa_tools_core/libs/github.py
+++ b/sa_tools_core/libs/github.py
@@ -115,8 +115,8 @@ class GithubRepo:
         files_sha = []
         # upload
         for path, content in files.items():
-            remote_content = self.get_file(path, reference=base_reference)
-            if remote_content['content'] == base64.encodebytes(content).decode():
+            base_file = self.get_file(path, reference=base_reference)
+            if base64.decodebytes(base_file['content'].encode()) == content:
                 logger.info(f'{path} unchange, ignored')
                 continue
             upload_result = self.upload_one_file(content)
@@ -134,6 +134,7 @@ class GithubRepo:
         base_branch = self.get_reference(base_reference)
         self.base_commit = self.get_commit(base_branch['object']['sha'])
         self.head_tree = self.create_tree(self.base_commit['tree']['sha'], files_sha)
+        return self.head_tree
 
     def commit(self, message):
         self.head_commit = self.create_commit(self.base_commit['sha'], self.head_tree['sha'], message)
@@ -159,15 +160,17 @@ class GithubRepo:
             path = list(files.keys())[0]
             content = files[path]
             base_file = self.get_file(path, reference=reference)
-            if base_file['content'] == base64.encodebytes(content).decode():
+            if base64.decodebytes(base_file['content'].encode()) == content:
                 logger.info(f'{path} unchange, ignored')
             else:
                 self.update_a_file(path, content, message, base_file['sha'])
             return
 
-        self.add(files, reference)
-        self.commit(message)
-        self.push(reference)
+        add_result = self.add(files, reference)
+        if add_result:
+            # do not continue if add not successful
+            self.commit(message)
+            self.push(reference)
 
 
 def commit_github(org, repo, branch, files, message, retry=2):


### PR DESCRIPTION
之前的比较函数因为 github 返回的 base64 和python 的 base64 换行位置不一样, 所以base64 密文并不相同, 现在修改成了 base64 decode 后比较明文

现在如果要更新的文件在github不存在, 不会报错, 会直接创建一个新的.