### PR TITLE
Add dockerfile for container env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.7.7-alpine
+
+WORKDIR sa-tools-core
+COPY . /sa-tools-core
+RUN set -ex \
+    && sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories \
+    && apk add --no-cache gcc python3-dev musl-dev libffi-dev openssl-dev ncdu \
+    && python -m pip install --index-url https://pypi.doubanio.com/simple --no-cache-dir .[script,icinga,tencentcloud] \
+    && apk del gcc python3-dev musl-dev libffi-dev openssl-dev \
+    && mkdir -p /etc/sa-tools/config.py \
+    && cp -rfv ./local_config.py.example /etc/sa-tools/ \
+    && mv -v /etc/sa-tools/local_config.py.example /etc/sa-tools/config.py \
+    && cp -rfv ./examples/config /etc/sa-tools/ \
+    && rm -rfv ./*
+
+VOLUME ["/etc/sa-tools/", "/etc/sa-tools-config/", "/usage-path", "/ncdu-data-path"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM python:3.7.7-alpine
 
+ARG ALPINE_REPO_HOST="mirrors.ustc.edu.cn"
+ARG PYPI_INDEX_URL="https://pypi.doubanio.com/simple"
+
 WORKDIR sa-tools-core
 COPY . /sa-tools-core
 RUN set -ex \
-    && sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories \
+    && sed -i "s/dl-cdn.alpinelinux.org/${ALPINE_REPO_HOST}/g" /etc/apk/repositories \
     && apk add --no-cache gcc python3-dev musl-dev libffi-dev openssl-dev ncdu \
-    && python -m pip install --index-url https://pypi.doubanio.com/simple --no-cache-dir .[script,icinga,tencentcloud] \
+    && python -m pip install --index-url ${PYPI_INDEX_URL} --no-cache-dir .[script,icinga,tencentcloud] \
     && apk del gcc python3-dev musl-dev libffi-dev openssl-dev \
     && mkdir -p /etc/sa-tools/config.py \
     && cp -rfv ./local_config.py.example /etc/sa-tools/ \


### PR DESCRIPTION
Add a docker file for sa-tools run in container env.

# usage 

```bash
# config.py should set config dir /etc/sa-tools, third part config /etc/sa-tools-config 
sudo docker run -v <config.py>:/etc/sa-tools -v <third part config>:/etc/sa-tools-config --rm -it sa-tools-core /bin/sh
```

If use sa-disk, you can map path waited to scan to `/usage-path`, ncdu exported `gz` file to `/usage-path` and use `sa-disk -c -r` options to set right parameters.

If use `sa-script` you must map inventory folder and ssh key to right dir. Feel free to map config file to the container.

# build 
```
git clone https://github.com/douban/sa-tools-core.git
cd sa-tools-core
# mind the . in the end
sudo docker build --build-arg ALPINE_REPO_HOST="mirrors.ustc.edu.cn" --build-arg PYPI_INDEX_URL="https://pypi.douban.com/simple" -t sa-tools-core:latest .
```