### PR TITLE
allow sentry init fail

### DIFF
--- a/sa_tools_core/libs/sentry.py
+++ b/sa_tools_core/libs/sentry.py
@@ -18,20 +18,23 @@ from sa_tools_core.consts import SENTRY_DSN
 
 logger = logging.getLogger(__name__)
 
-_client = Client(
-    dsn=SENTRY_DSN,
-    default_integrations=False,
-    integrations=[
-        ExcepthookIntegration(),
-        DedupeIntegration(),
-        StdlibIntegration(),
-        ModulesIntegration(),
-        ArgvIntegration(),
-    ],
-    max_breadcrumbs=5,
-    attach_stacktrace=True,
-)
-_hub = Hub(_client)
+try:
+    _client = Client(
+        dsn=SENTRY_DSN,
+        default_integrations=False,
+        integrations=[
+            ExcepthookIntegration(),
+            DedupeIntegration(),
+            StdlibIntegration(),
+            ModulesIntegration(),
+            ArgvIntegration(),
+        ],
+        max_breadcrumbs=5,
+        attach_stacktrace=True,
+    )
+    _hub = Hub(_client)
+except:
+    logger.exception('failed to load sentry: ')
 
 
 def report(msg=None, **kw):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from io import open
 from setuptools import setup, find_packages
 
-version = '0.4.3'
+version = '0.4.4'
 
 requirements = [
     'setuptools',


### PR DESCRIPTION
开发的时候不想配置正确的 sentry, init 失败的时候不要退出
fix #44 